### PR TITLE
Fix get expiring market bug

### DIFF
--- a/contracts/honeylemon/MarketContractProxy.sol
+++ b/contracts/honeylemon/MarketContractProxy.sol
@@ -132,7 +132,7 @@ contract MarketContractProxy is Ownable {
         uint contractsAdded = marketContracts.length;
 
         // If the marketContracts array has not had enough markets pushed into it to settle an old one then return 0x0.
-        if (contractsAdded <= CONTRACT_DURATION_DAYS) {
+        if (contractsAdded < CONTRACT_DURATION_DAYS) {
             return MarketContractMPX(address(0x0));
         }
         uint expiringIndex = contractsAdded - CONTRACT_DURATION_DAYS;


### PR DESCRIPTION
This PR fix a security issue in the `getExpiringMarketContract()` function. The current implementation will never return the index `0` to settle the first market.

**How to reproduce:**
```
const checkContractToSettle = (contractsLength, contractDay) => {
  for (let i = 0; i < contractsLength; i++) {
    let contractPushed = i + 1;

    contractPushed <= contractDay
      ? console.log('not settling')
      : console.log('settling contract index: ', contractPushed - contractDay);
  }
};

checkContractToSettle(30, 28);
```