### PR TITLE
[PVE-008] Fix insufficient checks in batchRedeem()

### DIFF
--- a/contracts/honeylemon/MarketContractProxy.sol
+++ b/contracts/honeylemon/MarketContractProxy.sol
@@ -8,6 +8,7 @@ import "openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol";
 import '../marketprotocol/MarketCollateralPool.sol';
 import '../marketprotocol/mpx/MarketContractFactoryMPX.sol';
 import '../marketprotocol/mpx/MarketContractMPX.sol';
+import '../marketprotocol/tokens/PositionToken.sol';
 
 import '../libraries/MathLib.sol';
 
@@ -384,35 +385,37 @@ contract MarketContractProxy is ReentrancyGuard, Ownable {
      * Only one side can be redeemed at a time. This is to simplify redemption as the same caller
      * will likely never be both long and short in the same contract.
      * @param tokenAddresses long/short token addresses
-     * @param marketAddresses market contracts addresses
      * @param tokensToRedeem amount of token to redeem
-     * @param traderLong true => trader long; false => trader short
      */
     function batchRedeem(
         address[] memory tokenAddresses, // Address of the long or short token to redeem
-        address[] memory marketAddresses, // Address of the market protocol
-        uint256[] memory tokensToRedeem, // the number of tokens to redeem
-        bool[] memory traderLong // if the trader is long or short
+        uint256[] memory tokensToRedeem // the number of tokens to redeem
     ) public nonReentrant {
         require(
-            tokenAddresses.length == marketAddresses.length &&
-                tokenAddresses.length == tokensToRedeem.length &&
-                tokenAddresses.length == traderLong.length,
+            tokenAddresses.length == tokensToRedeem.length,
             'Invalid input params'
         );
         require(this.owner() == msg.sender, "You don't own this DSProxy GTFO");
+
         MarketContractMPX marketInstance;
         MarketCollateralPool marketCollateralPool;
-        ERC20 tokenInstance;
+        PositionToken tokenInstance;
+
         // Loop through all tokens and preform redemption
         for (uint256 i = 0; i < tokenAddresses.length; i++) {
-            marketInstance = MarketContractMPX(marketAddresses[i]);
+            tokenInstance = PositionToken(tokenAddresses[i]);
+
+            require(
+                tokenInstance.balanceOf(address(this)) >= tokensToRedeem[i],
+                'Insufficient position token balance'
+            );
+
+            marketInstance = MarketContractMPX(tokenInstance.owner());
             marketCollateralPool = getCollateralPool(marketInstance);
-            tokenInstance = ERC20(tokenAddresses[i]);
 
             tokenInstance.approve(address(marketInstance), tokensToRedeem[i]);
 
-            if (traderLong[i]) {
+            if (uint8(tokenInstance.MARKET_SIDE()) == 0) {
                 // redeem n long tokens and 0 short tokens
                 marketCollateralPool.settleAndClose(
                     address(marketInstance),

--- a/honeylemon-intergration-tests/proxy-redemption-lifecycle-test.js
+++ b/honeylemon-intergration-tests/proxy-redemption-lifecycle-test.js
@@ -392,9 +392,7 @@ async function runExport() {
   const unwindLongTokenTx = marketContractProxy.contract.methods
     .batchRedeem(
       [longToken.address],
-      [marketContract.address],
-      [makerAmountToMint],
-      [true] // to indicate the token is long
+      [makerAmountToMint]
     )
     .encodeABI();
 
@@ -406,9 +404,7 @@ async function runExport() {
   const unwindShortTokenTx = marketContractProxy.contract.methods
     .batchRedeem(
       [shortToken.address],
-      [marketContract.address],
-      [makerAmountToMint],
-      [false] // to indicate the token is short
+      [makerAmountToMint]
     )
     .encodeABI();
 

--- a/src/lib/HoneylemonService.js
+++ b/src/lib/HoneylemonService.js
@@ -410,9 +410,7 @@ class HoneylemonService {
     if (longPositions.length > 0) {
       let longParams = {
         tokenAddresses: [],
-        marketContractAddresses: [],
-        numTokens: [],
-        isTradeLong: []
+        numTokens: []
       };
 
       // For each trade they've entered, add the position information to the params.
@@ -427,13 +425,7 @@ class HoneylemonService {
           // If this is the only instance of the token then add to the end of the array
           if (arrayIndex == -1) {
             longParams.tokenAddresses.push(position.longTokenAddress);
-            longParams.marketContractAddresses.push(
-              await this.marketContractProxy.methods
-                .marketContracts(position.marketId)
-                .call()
-            );
             longParams.numTokens.push(position.qtyToMint);
-            longParams.isTradeLong.push(true); // true set for long trades
           }
           // If this is not the only instance of this token then update the other previous
           // occupance with more tokens to redeem
@@ -448,9 +440,7 @@ class HoneylemonService {
       const batchRedemptionLongTx = this.marketContractProxy.methods
         .batchRedeem(
           longParams.tokenAddresses,
-          longParams.marketContractAddresses,
-          longParams.numTokens,
-          longParams.isTradeLong
+          longParams.numTokens
         )
         .encodeABI();
 
@@ -463,9 +453,7 @@ class HoneylemonService {
     if (shortPositions.length > 0) {
       let shortParams = {
         tokenAddresses: [],
-        marketContractAddresses: [],
-        numTokens: [],
-        isTradeLong: []
+        numTokens: []
       };
 
       for (let position of shortPositions) {
@@ -476,13 +464,7 @@ class HoneylemonService {
 
           if (arrayIndex == -1) {
             shortParams.tokenAddresses.push(position.shortTokenAddress);
-            shortParams.marketContractAddresses.push(
-              await this.marketContractProxy.methods
-                .marketContracts(position.marketId)
-                .call()
-            );
             shortParams.numTokens.push(position.qtyToMint);
-            shortParams.isTradeLong.push(false); // true set for long trades
           } else {
             shortParams.numTokens[arrayIndex] = (
               Number(shortParams.numTokens[arrayIndex]) + Number(position.qtyToMint)
@@ -494,9 +476,7 @@ class HoneylemonService {
       const batchRedemptionShortTx = this.marketContractProxy.methods
         .batchRedeem(
           shortParams.tokenAddresses,
-          shortParams.marketContractAddresses,
-          shortParams.numTokens,
-          shortParams.isTradeLong
+          shortParams.numTokens
         )
         .encodeABI();
 

--- a/test/honeylemon/MarketContractProxy.test.js
+++ b/test/honeylemon/MarketContractProxy.test.js
@@ -785,17 +785,13 @@ contract(
         // batch redeem call for long token
         let longTokenBatchTx = marketContractProxy.contract.methods.batchRedeem(
           longTokensAddresses,
-          marketContractsAddresses,
-          amounts,
-          isLongToken // to indicate the token is long
+          amounts
         )
         .encodeABI();
         // batch redeem call for short token
         let shortTokenBatchTx = marketContractProxy.contract.methods.batchRedeem(
           shortTokensAddresses,
-          marketContractsAddresses,
-          amounts,
-          isShortToken // to indicate the token is short
+          amounts
         ).encodeABI();
 
         // DSProxy Wallet instance


### PR DESCRIPTION
This PR refactor the `batchRedeem()` function to accept two arrays `tokenAddresses[]` and `tokensToRedeem[]` instead of four and add the needed check.

Closes #75 .