### PR TITLE
Set settlement delay

### DIFF
--- a/contracts/honeylemon/MarketContractProxy.sol
+++ b/contracts/honeylemon/MarketContractProxy.sol
@@ -387,12 +387,7 @@ contract MarketContractProxy is ReentrancyGuard, Ownable {
         address[] memory tokenAddresses, // Address of the long or short token to redeem
         uint256[] memory tokensToRedeem // the number of tokens to redeem
     ) public nonReentrant {
-        require(
-            tokenAddresses.length == marketAddresses.length &&
-                tokenAddresses.length == tokensToRedeem.length &&
-                tokenAddresses.length == traderLong.length,
-            "Invalid input params"
-        );
+        require(tokenAddresses.length == tokensToRedeem.length, "Invalid input params");
         require(this.owner() == msg.sender, "You don't own this DSProxy GTFO");
 
         MarketContractMPX marketInstance;

--- a/contracts/honeylemon/MarketContractProxy.sol
+++ b/contracts/honeylemon/MarketContractProxy.sol
@@ -30,6 +30,7 @@ contract MarketContractProxy is ReentrancyGuard, Ownable {
     address public HONEY_LEMON_ORACLE_ADDRESS;
     address public MINTER_BRIDGE_ADDRESS;
     address public COLLATERAL_TOKEN_ADDRESS; //imBTC
+    address public HONEY_MULTISIG;
 
     string public ORACLE_URL = 'null';
     string public ORACLE_STATISTIC = 'null';
@@ -78,12 +79,20 @@ contract MarketContractProxy is ReentrancyGuard, Ownable {
         address _marketContractFactoryMPX,
         address _honeyLemonOracle,
         address _minterBridge,
-        address _imBTCTokenAddress
+        address _imBTCTokenAddress,
+        address _honeyMultisig
     ) public ReentrancyGuard() {
+        require(_marketContractFactoryMPX != address(0), 'invalid MarketContractFactoryMPX address');
+        require(_honeyLemonOracle != address(0), 'invalid HoneyLemonOracle address');
+        require(_minterBridge != address(0), 'invalid MinterBridge address');
+        require(_imBTCTokenAddress != address(0), 'invalid IMBTC address');
+        require(_honeyMultisig != address(0), 'invalid HoneyMultisig address');
+
         marketContractFactoryMPX = MarketContractFactoryMPX(_marketContractFactoryMPX);
         HONEY_LEMON_ORACLE_ADDRESS = _honeyLemonOracle;
         MINTER_BRIDGE_ADDRESS = _minterBridge;
         COLLATERAL_TOKEN_ADDRESS = _imBTCTokenAddress;
+        HONEY_MULTISIG = _honeyMultisig;
 
         //Deploy a new DSProxyFactory instance to faciliate hot wallet creation
         dSProxyFactory = new DSProxyFactory();
@@ -153,6 +162,8 @@ contract MarketContractProxy is ReentrancyGuard, Ownable {
      * @param _honeyLemonOracleAddress oracle address
      */
     function setOracleAddress(address _honeyLemonOracleAddress) external onlyOwner {
+        require(_honeyLemonOracleAddress != address(0), 'invalid HoneyLemonOracle address');
+
         HONEY_LEMON_ORACLE_ADDRESS = _honeyLemonOracleAddress;
     }
 
@@ -162,6 +173,8 @@ contract MarketContractProxy is ReentrancyGuard, Ownable {
      * @param _minterBridgeAddress 0x minter bridge address
      */
     function setMinterBridgeAddress(address _minterBridgeAddress) external onlyOwner {
+        require(_minterBridgeAddress != address(0), 'invalid MinterBridge address');
+
         MINTER_BRIDGE_ADDRESS = _minterBridgeAddress;
     }
 
@@ -172,6 +185,17 @@ contract MarketContractProxy is ReentrancyGuard, Ownable {
      */
     function setMarketContractSpecs(uint[7] calldata _params) external onlyOwner {
         marketContractSpecs = _params;
+    }
+
+    /**
+     * @notice Set honey multisig address
+     * @dev can only be called by owner
+     * @param _honeyMultisig multisig address
+     */
+    function setHoneyMultisig(address _honeyMultisig) external onlyOwner {
+        require(_honeyMultisig != address(0), 'invalid HoneyMultisig address');
+
+        HONEY_MULTISIG = _honeyMultisig;
     }
 
     ////////////////////////
@@ -592,6 +616,7 @@ contract MarketContractProxy is ReentrancyGuard, Ownable {
         uint index = marketContracts.push(contractAddress) - 1;
         addressToMarketId[contractAddress] = index;
         MarketContractMPX marketContract = MarketContractMPX(contractAddress);
+        marketContract.transferOwnership(HONEY_MULTISIG);
         emit MarketContractDeployed(
             currentMRI,
             marketAndsTokenNames[0],

--- a/contracts/honeylemon/MarketContractProxy.sol
+++ b/contracts/honeylemon/MarketContractProxy.sol
@@ -30,7 +30,6 @@ contract MarketContractProxy is ReentrancyGuard, Ownable {
     address public HONEY_LEMON_ORACLE_ADDRESS;
     address public MINTER_BRIDGE_ADDRESS;
     address public COLLATERAL_TOKEN_ADDRESS; //imBTC
-    address public HONEY_MULTISIG;
 
     string public ORACLE_URL = 'null';
     string public ORACLE_STATISTIC = 'null';
@@ -79,20 +78,17 @@ contract MarketContractProxy is ReentrancyGuard, Ownable {
         address _marketContractFactoryMPX,
         address _honeyLemonOracle,
         address _minterBridge,
-        address _imBTCTokenAddress,
-        address _honeyMultisig
+        address _imBTCTokenAddress
     ) public ReentrancyGuard() {
         require(_marketContractFactoryMPX != address(0), 'invalid MarketContractFactoryMPX address');
         require(_honeyLemonOracle != address(0), 'invalid HoneyLemonOracle address');
         require(_minterBridge != address(0), 'invalid MinterBridge address');
         require(_imBTCTokenAddress != address(0), 'invalid IMBTC address');
-        require(_honeyMultisig != address(0), 'invalid HoneyMultisig address');
 
         marketContractFactoryMPX = MarketContractFactoryMPX(_marketContractFactoryMPX);
         HONEY_LEMON_ORACLE_ADDRESS = _honeyLemonOracle;
         MINTER_BRIDGE_ADDRESS = _minterBridge;
         COLLATERAL_TOKEN_ADDRESS = _imBTCTokenAddress;
-        HONEY_MULTISIG = _honeyMultisig;
 
         //Deploy a new DSProxyFactory instance to faciliate hot wallet creation
         dSProxyFactory = new DSProxyFactory();
@@ -185,17 +181,6 @@ contract MarketContractProxy is ReentrancyGuard, Ownable {
      */
     function setMarketContractSpecs(uint[7] calldata _params) external onlyOwner {
         marketContractSpecs = _params;
-    }
-
-    /**
-     * @notice Set honey multisig address
-     * @dev can only be called by owner
-     * @param _honeyMultisig multisig address
-     */
-    function setHoneyMultisig(address _honeyMultisig) external onlyOwner {
-        require(_honeyMultisig != address(0), 'invalid HoneyMultisig address');
-
-        HONEY_MULTISIG = _honeyMultisig;
     }
 
     ////////////////////////
@@ -616,7 +601,7 @@ contract MarketContractProxy is ReentrancyGuard, Ownable {
         uint index = marketContracts.push(contractAddress) - 1;
         addressToMarketId[contractAddress] = index;
         MarketContractMPX marketContract = MarketContractMPX(contractAddress);
-        marketContract.transferOwnership(HONEY_MULTISIG);
+        marketContract.transferOwnership(owner());
         emit MarketContractDeployed(
             currentMRI,
             marketAndsTokenNames[0],

--- a/contracts/marketprotocol/MarketContract.sol
+++ b/contracts/marketprotocol/MarketContract.sol
@@ -41,7 +41,7 @@ contract MarketContract is Ownable {
     uint public COLLATERAL_TOKEN_FEE_PER_UNIT;
     uint public MKT_TOKEN_FEE_PER_UNIT;
     uint public EXPIRATION;
-    uint public SETTLEMENT_DELAY = 0;
+    uint public SETTLEMENT_DELAY = 1 days;
     address public LONG_POSITION_TOKEN;
     address public SHORT_POSITION_TOKEN;
 

--- a/honeylemon-intergration-tests/proxy-redemption-lifecycle-test.js
+++ b/honeylemon-intergration-tests/proxy-redemption-lifecycle-test.js
@@ -381,6 +381,9 @@ async function runExport() {
     }
   );
 
+  // Advance time again to get past the settlement delay
+  await time.increase(contractDuration);
+
   /**********************************************
    * Redeem long and short tokens against market *
    ***********************************************/

--- a/migrations/4_market_contract_proxy.js
+++ b/migrations/4_market_contract_proxy.js
@@ -27,8 +27,7 @@ module.exports = async function(deployer, network, accounts) {
     marketContractFactoryMPX.address,
     accounts[0],
     minterBridge.address,
-    collateralToken.address,
-    process.env.HONEYLEMON_MULTISIG || accounts[8]
+    collateralToken.address
   );
 
   console.log('👉 Deployed Market Contract Proxy');

--- a/migrations/4_market_contract_proxy.js
+++ b/migrations/4_market_contract_proxy.js
@@ -27,10 +27,13 @@ module.exports = async function(deployer, network, accounts) {
     marketContractFactoryMPX.address,
     accounts[0],
     minterBridge.address,
-    collateralToken.address
+    collateralToken.address,
+    process.env.HONEYLEMON_MULTISIG || accounts[8]
   );
 
   console.log('👉 Deployed Market Contract Proxy');
+
+  marketContractProxy.transferOwnership(process.env.HONEYLEMON_MULTISIG || accounts[8])
 
   // Transfer all appropriate rights from the deployed market protocol to marketContractProxy:
   // Point the 0x MinterBridge to the marketContractProxy

--- a/test/honeylemon/MarketContractProxy.test.js
+++ b/test/honeylemon/MarketContractProxy.test.js
@@ -560,6 +560,9 @@ contract(
             (await imbtc.balanceOf(takerAddress)).toString()
           );
 
+          // advance time after settlement delay
+          await time.increaseTo((await marketContractMpx.settlementTimeStamp()).toNumber() + (3600 * 24));
+
           // miner & investor redeem
           await marketContractPool.settleAndClose(marketContractMpx.address, amount, 0, {
             from: takerAddress
@@ -773,6 +776,12 @@ contract(
             await marketContractMpx.isSettled(),
             true
           );
+
+          // time should be after last token's contract passed + settlement delay
+          if (marketContract.length-1 == i) {
+            // advance time after settlement delay
+            await time.increaseTo((await marketContractMpx.settlementTimeStamp()).toNumber() + (3600 * 24));
+          }
         }
 
         let makerImbtcBalanceBefore = new BigNumber(

--- a/test/honeylemon/MarketContractProxy.test.js
+++ b/test/honeylemon/MarketContractProxy.test.js
@@ -875,7 +875,12 @@ contract(
         let amount = new BigNumber(10);
 
         // deploy new markets to settle & batch redeem
-        for (let i = marketContract.length; i < 33; i++) {
+        const contractsToDeploy = 3;
+        for (
+          let i = marketContract.length;
+          i < marketContract.length + contractsToDeploy;
+          i++
+        ) {
           let _marketAndsTokenNames = [];
           _marketAndsTokenNames.push(web3.utils.fromAscii("BTC"));
           _marketAndsTokenNames.push(web3.utils.fromAscii("MRI-BTC-28D-00000000-Long"));
@@ -922,7 +927,11 @@ contract(
         let expectedTakerReturnedCollateral = new BigNumber(0);
         // settle last three contracts
         marketContract = await marketContractProxy.getAllMarketContracts();
-        for (let i = marketContract.length - 2; i < marketContract.length; i++) {
+        for (
+          let i = marketContract.length - contractsToDeploy;
+          i < marketContract.length;
+          i++
+        ) {
           let marketContractMpx = await MarketContractMPX.at(marketContract[i]);
 
           amounts.push(amount.toString());

--- a/test/honeylemon/MarketContractProxy.test.js
+++ b/test/honeylemon/MarketContractProxy.test.js
@@ -1,18 +1,20 @@
-const BigNumber = require('bignumber.js');
-const { expectRevert, ether, time } = require('@openzeppelin/test-helpers');
+const BigNumber = require("bignumber.js");
+const { expectRevert, ether, time } = require("@openzeppelin/test-helpers");
 
-const MinterBridge = artifacts.require('MinterBridge');
-const MarketContractProxy = artifacts.require('MarketContractProxy');
-const CollateralToken = artifacts.require('CollateralToken'); // IMBTC
-const PaymentToken = artifacts.require('PaymentToken'); // USDC
-const MarketContractFactoryMPX = artifacts.require('MarketContractFactoryMPX');
-const MarketContractMPX = artifacts.require('MarketContractMPX');
-const MarketCollateralPool = artifacts.require('MarketCollateralPool');
-const PositionToken = artifacts.require('PositionToken'); // Long & Short tokens
-const DSProxy = artifacts.require('DSProxy');
+const MinterBridge = artifacts.require("MinterBridge");
+const MarketContractProxy = artifacts.require("MarketContractProxy");
+const CollateralToken = artifacts.require("CollateralToken"); // IMBTC
+const PaymentToken = artifacts.require("PaymentToken"); // USDC
+const MarketContractFactoryMPX = artifacts.require("MarketContractFactoryMPX");
+const MarketContractMPX = artifacts.require("MarketContractMPX");
+const MarketCollateralPool = artifacts.require("MarketCollateralPool");
+const PositionToken = artifacts.require("PositionToken"); // Long & Short tokens
+const DSProxy = artifacts.require("DSProxy");
 
 // Helper libraries
-const { PayoutCalculator } = require('../../honeylemon-intergration-tests/helpers/payout-calculator');
+const {
+  PayoutCalculator
+} = require("../../honeylemon-intergration-tests/helpers/payout-calculator");
 
 const isMarketExpired = (contractIndex, contractDay) => {
   return contractIndex < contractDay ? false : true;
@@ -62,11 +64,22 @@ const calculateExpectedCollateralToReturn = (
   return neededCollateral;
 };
 
-const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000';
+const ADDRESS_ZERO = "0x0000000000000000000000000000000000000000";
 
 contract(
-  'MarketContractProxy',
-  ([honeyLemonOracle, makerAddress, takerAddress, , , , , _0xBridgeProxy, honeyMultisig, random]) => {
+  "MarketContractProxy",
+  ([
+    honeyLemonOracle,
+    makerAddress,
+    takerAddress,
+    ,
+    ,
+    ,
+    ,
+    _0xBridgeProxy,
+    honeyMultisig,
+    random
+  ]) => {
     let minterBridge, marketContractProxy, imbtc, usdc, pc, _currentMri, _expiration;
 
     before(async () => {
@@ -88,79 +101,79 @@ contract(
       _expiration = Math.round(new Date().getTime() / 1000) + 3600 * 24 * 28;
     });
 
-    describe('Check deployment config', () => {
-      it('check honeylemon oracle address', async () => {
+    describe("Check deployment config", () => {
+      it("check honeylemon oracle address", async () => {
         assert.equal(
           await marketContractProxy.HONEY_LEMON_ORACLE_ADDRESS(),
           honeyLemonOracle,
-          'Honeylemon oracle address mismatch'
+          "Honeylemon oracle address mismatch"
         );
       });
-      it('check 0x minter bridge address', async () => {
+      it("check 0x minter bridge address", async () => {
         assert.equal(
           await marketContractProxy.MINTER_BRIDGE_ADDRESS(),
           minterBridge.address,
-          '0x minter bridge address mismatch'
+          "0x minter bridge address mismatch"
         );
       });
-      it('check collateral token address', async () => {
+      it("check collateral token address", async () => {
         assert.equal(
           await marketContractProxy.COLLATERAL_TOKEN_ADDRESS(),
           imbtc.address,
-          'Collateral token address mismatch'
+          "Collateral token address mismatch"
         );
       });
-      it('check floor price', async () => {
+      it("check floor price", async () => {
         assert.equal(
           (await marketContractProxy.marketContractSpecs(0)).toString(),
-          '0',
-          'Floor price mismatch'
+          "0",
+          "Floor price mismatch"
         );
       });
-      it('check cap price', async () => {
+      it("check cap price", async () => {
         assert.equal(
           (await marketContractProxy.marketContractSpecs(1)).toString(),
-          '0',
-          'Cap price mismatch'
+          "0",
+          "Cap price mismatch"
         );
       });
-      it('check cap price', async () => {
+      it("check cap price", async () => {
         assert.equal(
           (await marketContractProxy.marketContractSpecs(2)).toString(),
-          '8',
-          'Price decimal places mismatch'
+          "8",
+          "Price decimal places mismatch"
         );
       });
-      it('check quantity multiplier', async () => {
+      it("check quantity multiplier", async () => {
         assert.equal(
           (await marketContractProxy.marketContractSpecs(3)).toString(),
-          '1',
-          'Qty multiplier places mismatch'
+          "1",
+          "Qty multiplier places mismatch"
         );
       });
-      it('check fee in basis points', async () => {
+      it("check fee in basis points", async () => {
         assert.equal(
           (await marketContractProxy.marketContractSpecs(4)).toString(),
-          '0',
-          'Fee in basis points mismatch'
+          "0",
+          "Fee in basis points mismatch"
         );
       });
-      it('check market fee in basis points', async () => {
+      it("check market fee in basis points", async () => {
         assert.equal(
           (await marketContractProxy.marketContractSpecs(5)).toString(),
-          '0',
-          'Market fee in basis points mismatch'
+          "0",
+          "Market fee in basis points mismatch"
         );
       });
     });
 
-    describe('Check permissions', async () => {
-      it('should revert setting oracle address by non-owner', async () => {
+    describe("Check permissions", async () => {
+      it("should revert setting oracle address by non-owner", async () => {
         await expectRevert.unspecified(
           marketContractProxy.setOracleAddress(honeyLemonOracle, { from: random })
         );
       });
-      it('should revert setting minter bridge address by non-owner', async () => {
+      it("should revert setting minter bridge address by non-owner", async () => {
         await expectRevert.unspecified(
           marketContractProxy.setMinterBridgeAddress(minterBridge.address, {
             from: random
@@ -169,13 +182,13 @@ contract(
       });
     });
 
-    describe('deploy new market contract', async () => {
+    describe("deploy new market contract", async () => {
       const _marketAndsTokenNames = [];
-      _marketAndsTokenNames.push(web3.utils.fromAscii('BTC'));
-      _marketAndsTokenNames.push(web3.utils.fromAscii('MRI-BTC-28D-00000000-Long'));
-      _marketAndsTokenNames.push(web3.utils.fromAscii('MRI-BTC-28D-00000000-Short'));
+      _marketAndsTokenNames.push(web3.utils.fromAscii("BTC"));
+      _marketAndsTokenNames.push(web3.utils.fromAscii("MRI-BTC-28D-00000000-Long"));
+      _marketAndsTokenNames.push(web3.utils.fromAscii("MRI-BTC-28D-00000000-Short"));
 
-      it('generate contract specs', async () => {
+      it("generate contract specs", async () => {
         let _capPrice = calculateCapPrice(28, _currentMri);
         let dailySpecs = await marketContractProxy.generateContractSpecs(
           _currentMri,
@@ -185,16 +198,16 @@ contract(
         assert.equal(
           _capPrice.precision(4).toString(),
           new BigNumber(dailySpecs[1].toString()).precision(4).toString(),
-          'Cap price mismatch'
+          "Cap price mismatch"
         );
         assert.equal(
           _expiration,
           dailySpecs[6].toString(),
-          'Expiration timestamp mismatch'
+          "Expiration timestamp mismatch"
         );
       });
 
-      it('should revert daily settlement from address other than honeylemon oracle', async () => {
+      it("should revert daily settlement from address other than honeylemon oracle", async () => {
         await expectRevert.unspecified(
           marketContractProxy.dailySettlement(
             0,
@@ -206,16 +219,16 @@ contract(
         );
       });
 
-      it('should revert daily settlement when passed MRI equal to zero', async () => {
+      it("should revert daily settlement when passed MRI equal to zero", async () => {
         await expectRevert(
           marketContractProxy.dailySettlement(0, 0, _marketAndsTokenNames, _expiration, {
             from: honeyLemonOracle
           }),
-          'Current MRI value cant be zero'
+          "Current MRI value cant be zero"
         );
       });
 
-      it('daily settlement', async () => {
+      it("daily settlement", async () => {
         let allMarketContractsBefore = await marketContractProxy.getAllMarketContracts();
 
         await marketContractProxy.dailySettlement(
@@ -228,35 +241,35 @@ contract(
 
         let allMarketContractsAfter = await marketContractProxy.getAllMarketContracts();
         let latestMarket = await marketContractProxy.getLatestMarketContract();
-        let marketCollateralPool = await (await MarketContractMPX.at(
-          latestMarket
-        )).COLLATERAL_POOL_ADDRESS();
+        let marketCollateralPool = await (
+          await MarketContractMPX.at(latestMarket)
+        ).COLLATERAL_POOL_ADDRESS();
 
         assert.equal(
           (await marketContractProxy.getLatestMri()).toString(),
           _currentMri,
-          'latest MRI value mismatch'
+          "latest MRI value mismatch"
         );
         assert.equal(
           allMarketContractsAfter.length - allMarketContractsBefore.length,
           1,
-          'Market contracts array length mismatch'
+          "Market contracts array length mismatch"
         );
         assert.equal(
           await marketContractProxy.getLatestMarketContract(),
           allMarketContractsAfter[0],
-          'Latest market contract address mismatch'
+          "Latest market contract address mismatch"
         );
         assert.equal(
           await marketContractProxy.getLatestMarketCollateralPool(),
           marketCollateralPool,
-          'Latest market collateral pool address mismatch'
+          "Latest market collateral pool address mismatch"
         );
       });
     });
 
-    describe('Collateral requirement', () => {
-      it('calculate required collateral', async () => {
+    describe("Collateral requirement", () => {
+      it("calculate required collateral", async () => {
         let amount = new BigNumber(100);
         let expectedCollateralRequirement = amount
           .multipliedBy(_currentMri)
@@ -277,12 +290,12 @@ contract(
         assert.equal(
           absoluteDriftError.lt(new BigNumber(0.001)),
           true,
-          'collateral required mismatch'
+          "collateral required mismatch"
         );
       });
     });
 
-    describe('Mint positions token', () => {
+    describe("Mint positions token", () => {
       const amount = new BigNumber(100);
       let neededCollateral;
 
@@ -306,7 +319,7 @@ contract(
         );
       });
 
-      it('should revert minting positions tokens if caller is not minter bridge contract', async () => {
+      it("should revert minting positions tokens if caller is not minter bridge contract", async () => {
         await expectRevert(
           marketContractProxy.mintPositionTokens(
             amount.toString(),
@@ -314,11 +327,11 @@ contract(
             makerAddress,
             { from: random }
           ),
-          'Only Minter Bridge'
+          "Only Minter Bridge"
         );
       });
 
-      it('mint positions tokens', async () => {
+      it("mint positions tokens", async () => {
         // get market contract
         let latestMarketContractAddr = await marketContractProxy.getLatestMarketContract();
         let latestMarketContract = await MarketContractMPX.at(latestMarketContractAddr);
@@ -360,38 +373,38 @@ contract(
             .minus(makerLongTokenBalanceBefore)
             .toString(),
           0,
-          'Miner long token balance mismatch'
+          "Miner long token balance mismatch"
         );
         assert.equal(
           new BigNumber((await marketContractProxy.balanceOf(takerAddress)).toString())
             .minus(takerLongTokenBalanceBefore)
             .toString(),
           amount.toString(),
-          'Investor long token balance mismatch'
+          "Investor long token balance mismatch"
         );
         assert.equal(
           new BigNumber((await sToken.balanceOf(makerAddress)).toString())
             .minus(makerShortTokenBalanceBefore)
             .toString(),
           amount.toString(),
-          'Miner short token balance mismatch'
+          "Miner short token balance mismatch"
         );
         assert.equal(
           new BigNumber((await sToken.balanceOf(takerAddress)).toString())
             .minus(takerShortTokenBalanceBefore)
             .toString(),
           0,
-          'Investor short token balance mismatch'
+          "Investor short token balance mismatch"
         );
         assert.equal(
           (await imbtc.balanceOf(marketCollateralPool.address)).toString(),
           neededCollateral.toString(),
-          'Market collateral pool balance mismatch'
+          "Market collateral pool balance mismatch"
         );
       });
     });
 
-    describe('Contract settlement', () => {
+    describe("Contract settlement", () => {
       before(async () => {
         // deploy 27 more contract to get expired ones
         let targetLength = new BigNumber(
@@ -401,9 +414,9 @@ contract(
 
         for (let i = 0; i < targetLength - currentLength; i++) {
           let _marketAndsTokenNames = [];
-          _marketAndsTokenNames.push(web3.utils.fromAscii('BTC'));
-          _marketAndsTokenNames.push(web3.utils.fromAscii('MRI-BTC-28D-00000000-Long'));
-          _marketAndsTokenNames.push(web3.utils.fromAscii('MRI-BTC-28D-00000000-Short'));
+          _marketAndsTokenNames.push(web3.utils.fromAscii("BTC"));
+          _marketAndsTokenNames.push(web3.utils.fromAscii("MRI-BTC-28D-00000000-Long"));
+          _marketAndsTokenNames.push(web3.utils.fromAscii("MRI-BTC-28D-00000000-Short"));
           let _mri = new BigNumber(pc.getMRIDataForDay(i + 1)).multipliedBy(
             new BigNumber(1e8)
           );
@@ -446,24 +459,24 @@ contract(
         assert.equal(
           new BigNumber(await marketContractProxy.CONTRACT_DURATION_DAYS()).toFixed(),
           targetLength,
-          'market length mismatch'
+          "market length mismatch"
         );
       });
 
-      describe('case: latestMri > PRICE_CAP', async () => {
-        it('deploy new contract and settle contract #1: case Mri > PRICE_CAP', async () => {
+      describe("case: latestMri > PRICE_CAP", async () => {
+        it("deploy new contract and settle contract #1: case Mri > PRICE_CAP", async () => {
           let marketsContracts = await marketContractProxy.getAllMarketContracts();
           assert.equal(
             (await marketContractProxy.getExpiringMarketContract()).toString(),
             marketsContracts[0],
-            'expiring market contract mismatch'
+            "expiring market contract mismatch"
           );
 
           // deploy new contract & settle first market contract
           let _marketAndsTokenNames = [];
-          _marketAndsTokenNames.push(web3.utils.fromAscii('BTC'));
-          _marketAndsTokenNames.push(web3.utils.fromAscii('MRI-BTC-28D-00000000-Long'));
-          _marketAndsTokenNames.push(web3.utils.fromAscii('MRI-BTC-28D-00000000-Short'));
+          _marketAndsTokenNames.push(web3.utils.fromAscii("BTC"));
+          _marketAndsTokenNames.push(web3.utils.fromAscii("MRI-BTC-28D-00000000-Long"));
+          _marketAndsTokenNames.push(web3.utils.fromAscii("MRI-BTC-28D-00000000-Short"));
           let _loopbackMri = new BigNumber(1).multipliedBy(new BigNumber(1e8));
           let _mri = new BigNumber(pc.getMRIDataForDay(29)).multipliedBy(
             new BigNumber(1e8)
@@ -483,21 +496,21 @@ contract(
           assert.equal(
             (await marketContractMpx.lastPrice()).toString(),
             _loopbackMri.toString(),
-            'last MRI value mismatch'
+            "last MRI value mismatch"
           );
           assert.isAbove(
             (await marketContractMpx.lastPrice()).toNumber(),
             (await marketContractMpx.PRICE_CAP()).toNumber(),
-            'latest pushed MRI is not above price cap'
+            "latest pushed MRI is not above price cap"
           );
           assert.equal(
             await marketContractMpx.isSettled(),
             true,
-            'market contract did not settle when latest MRI above price cap'
+            "market contract did not settle when latest MRI above price cap"
           );
         });
 
-        it('should revert settling an already settled contract', async () => {
+        it("should revert settling an already settled contract", async () => {
           let marketsContracts = await marketContractProxy.getAllMarketContracts();
 
           await expectRevert.unspecified(
@@ -509,7 +522,7 @@ contract(
           );
         });
 
-        it('redeem long&short token', async () => {
+        it("redeem long&short token", async () => {
           let marketsContracts = await marketContractProxy.getAllMarketContracts();
           let marketContractMpx = await MarketContractMPX.at(marketsContracts[0]);
 
@@ -542,7 +555,9 @@ contract(
           );
 
           // advance time after settlement delay
-          await time.increaseTo((await marketContractMpx.settlementTimeStamp()).toNumber() + (3600 * 24));
+          await time.increaseTo(
+            (await marketContractMpx.settlementTimeStamp()).toNumber() + 3600 * 24
+          );
 
           // miner & investor redeem
           await marketContractPool.settleAndClose(marketContractMpx.address, amount, 0, {
@@ -578,17 +593,17 @@ contract(
           assert.equal(
             makerImbtcBalanceAfter.minus(makerImbtcBalanceBefore).toString(),
             expectedMakerReturnedCollateral.toString(),
-            'maker returned collateral mismatch'
+            "maker returned collateral mismatch"
           );
           assert.equal(
             takerImbtcBalanceAfter.minus(takerImbtcBalanceBefore).toString(),
             expectedTakerReturnedCollateral.toString(),
-            'taker returned collateral mismatch'
+            "taker returned collateral mismatch"
           );
         });
       });
 
-      describe('case: current date passed expiration date', async () => {
+      describe("case: current date passed expiration date", async () => {
         before(async () => {
           let marketsContracts = await marketContractProxy.getAllMarketContracts();
           let marketContractMpx = await MarketContractMPX.at(marketsContracts[1]);
@@ -596,19 +611,19 @@ contract(
           await time.increaseTo((await marketContractMpx.EXPIRATION()).toNumber() + 10);
         });
 
-        it('deploy new contract and settle contract #2: case now > EXPIRATION', async () => {
+        it("deploy new contract and settle contract #2: case now > EXPIRATION", async () => {
           let marketsContracts = await marketContractProxy.getAllMarketContracts();
           assert.equal(
             (await marketContractProxy.getExpiringMarketContract()).toString(),
             marketsContracts[1],
-            'expiring market contract mismatch'
+            "expiring market contract mismatch"
           );
 
           // deploy new contract & settle first market contract
           let _marketAndsTokenNames = [];
-          _marketAndsTokenNames.push(web3.utils.fromAscii('BTC'));
-          _marketAndsTokenNames.push(web3.utils.fromAscii('MRI-BTC-28D-00000000-Long'));
-          _marketAndsTokenNames.push(web3.utils.fromAscii('MRI-BTC-28D-00000000-Short'));
+          _marketAndsTokenNames.push(web3.utils.fromAscii("BTC"));
+          _marketAndsTokenNames.push(web3.utils.fromAscii("MRI-BTC-28D-00000000-Long"));
+          _marketAndsTokenNames.push(web3.utils.fromAscii("MRI-BTC-28D-00000000-Short"));
           let _loopbackMri = new BigNumber(pc.getMRIDataForDay(30)).multipliedBy(
             new BigNumber(1e8)
           );
@@ -630,38 +645,42 @@ contract(
           assert.equal(
             (await marketContractMpx.lastPrice()).toString(),
             _loopbackMri.toString(),
-            'last MRI value mismatch'
+            "last MRI value mismatch"
           );
           assert.isBelow(
             (await marketContractMpx.lastPrice()).toNumber(),
             (await marketContractMpx.PRICE_CAP()).toNumber(),
-            'latest pushed MRI is not below price cap'
+            "latest pushed MRI is not below price cap"
           );
           assert.isAbove(
             (await marketContractMpx.lastPrice()).toNumber(),
             (await marketContractMpx.PRICE_FLOOR()).toNumber(),
-            'latest pushed MRI is not above price floor'
+            "latest pushed MRI is not above price floor"
           );
           assert.equal(
             await marketContractMpx.isSettled(),
             true,
-            'market contract did not settle when latest MRI above price cap'
+            "market contract did not settle when latest MRI above price cap"
           );
         });
       });
 
-      describe('Arbitrate settlement', async () => {
+      describe("Arbitrate settlement", async () => {
         let amount = new BigNumber(10);
-        let marketContractMpx, makerReturnedCollateralBeforeArbitrate, takerReturnedCollateralBeforeArbitrate, makerReturnedCollateralAfterArbitrate, takerrReturnedCollateralAfterArbitrate;
+        let marketContractMpx,
+          makerReturnedCollateralBeforeArbitrate,
+          takerReturnedCollateralBeforeArbitrate,
+          makerReturnedCollateralAfterArbitrate,
+          takerrReturnedCollateralAfterArbitrate;
 
         before(async () => {
           let marketsContracts = await marketContractProxy.getAllMarketContracts();
           marketContractMpx = await MarketContractMPX.at(marketsContracts[2]);
 
           let _marketAndsTokenNames = [];
-          _marketAndsTokenNames.push(web3.utils.fromAscii('BTC'));
-          _marketAndsTokenNames.push(web3.utils.fromAscii('MRI-BTC-28D-00000000-Long'));
-          _marketAndsTokenNames.push(web3.utils.fromAscii('MRI-BTC-28D-00000000-Short'));
+          _marketAndsTokenNames.push(web3.utils.fromAscii("BTC"));
+          _marketAndsTokenNames.push(web3.utils.fromAscii("MRI-BTC-28D-00000000-Long"));
+          _marketAndsTokenNames.push(web3.utils.fromAscii("MRI-BTC-28D-00000000-Short"));
           let _mri = new BigNumber(pc.getMRIDataForDay(30)).multipliedBy(
             new BigNumber(1e8)
           );
@@ -715,16 +734,12 @@ contract(
           assert.equal(
             (await marketContractMpx.lastPrice()).toString(),
             _mri.toString(),
-            'last price value mismatch'
+            "last price value mismatch"
           );
-          assert.equal(
-            await marketContractMpx.isSettled(),
-            true,
-            'market not settled'
-          )
+          assert.equal(await marketContractMpx.isSettled(), true, "market not settled");
         });
 
-        it('arbitrate settlement value', async () => {
+        it("arbitrate settlement value", async () => {
           let makerImbtcBalanceBefore = new BigNumber(
             (await imbtc.balanceOf(makerAddress)).toString()
           );
@@ -735,19 +750,15 @@ contract(
           let _mri = new BigNumber(pc.getMRIDataForDay(32)).multipliedBy(
             new BigNumber(1e8)
           );
-          
+
           await marketContractMpx.arbitrateSettlement(_mri, { from: honeyMultisig });
 
           assert.equal(
             (await marketContractMpx.lastPrice()).toString(),
             _mri.toString(),
-            'last price value mismatch'
+            "last price value mismatch"
           );
-          assert.equal(
-            await marketContractMpx.isSettled(),
-            true,
-            'market not settled'
-          );
+          assert.equal(await marketContractMpx.isSettled(), true, "market not settled");
 
           makerReturnedCollateralAfterArbitrate = calculateExpectedCollateralToReturn(
             new BigNumber((await marketContractMpx.PRICE_FLOOR()).toString()),
@@ -766,18 +777,26 @@ contract(
             new BigNumber((await marketContractMpx.settlementPrice()).toString())
           );
 
-          assert.notEqual(makerReturnedCollateralAfterArbitrate.toString(), makerReturnedCollateralBeforeArbitrate.toString());
-          assert.notEqual(takerrReturnedCollateralAfterArbitrate.toString(), takerReturnedCollateralBeforeArbitrate.toString());
+          assert.notEqual(
+            makerReturnedCollateralAfterArbitrate.toString(),
+            makerReturnedCollateralBeforeArbitrate.toString()
+          );
+          assert.notEqual(
+            takerrReturnedCollateralAfterArbitrate.toString(),
+            takerReturnedCollateralBeforeArbitrate.toString()
+          );
 
-          // increate time to settlement time + settlement delay days 
-          await time.increaseTo((await marketContractMpx.settlementTimeStamp()).toNumber() + (3600 * 24));
+          // increate time to settlement time + settlement delay days
+          await time.increaseTo(
+            (await marketContractMpx.settlementTimeStamp()).toNumber() + 3600 * 24
+          );
 
           // get market pool
           let marketCollateralPoolAddr = await marketContractMpx.COLLATERAL_POOL_ADDRESS();
           let marketContractPool = await MarketCollateralPool.at(
             marketCollateralPoolAddr
           );
-          
+
           // miner & investor redeem
           await marketContractPool.settleAndClose(marketContractMpx.address, amount, 0, {
             from: takerAddress
@@ -785,7 +804,7 @@ contract(
           await marketContractPool.settleAndClose(marketContractMpx.address, 0, amount, {
             from: makerAddress
           });
-          
+
           let makerImbtcBalanceAfter = new BigNumber(
             (await imbtc.balanceOf(makerAddress)).toString()
           );
@@ -796,33 +815,53 @@ contract(
           assert.equal(
             makerImbtcBalanceAfter.minus(makerImbtcBalanceBefore).toString(),
             makerReturnedCollateralAfterArbitrate.toString(),
-            'maker returned collateral mismatch'
+            "maker returned collateral mismatch"
           );
           assert.equal(
             takerImbtcBalanceAfter.minus(takerImbtcBalanceBefore).toString(),
             takerrReturnedCollateralAfterArbitrate.toString(),
-            'taker returned collateral mismatch'
+            "taker returned collateral mismatch"
           );
         });
       });
     });
 
-    describe('DSProxy', () => {
-      it('create a proxy wallet for maker & taker', async() => {
-        assert.equal(await marketContractProxy.getUserAddressOrDSProxy(makerAddress), makerAddress, 'maker address mismatch');
-        assert.equal(await marketContractProxy.getUserAddressOrDSProxy(takerAddress), takerAddress, 'taker address mismatch');
+    describe("DSProxy", () => {
+      it("create a proxy wallet for maker & taker", async () => {
+        assert.equal(
+          await marketContractProxy.getUserAddressOrDSProxy(makerAddress),
+          makerAddress,
+          "maker address mismatch"
+        );
+        assert.equal(
+          await marketContractProxy.getUserAddressOrDSProxy(takerAddress),
+          takerAddress,
+          "taker address mismatch"
+        );
 
         await marketContractProxy.createDSProxyWallet({ from: makerAddress });
         await marketContractProxy.createDSProxyWallet({ from: takerAddress });
 
-        let makerDsProxyWallet = await marketContractProxy.getUserAddressOrDSProxy(makerAddress);
-        let takerDsProxyWallet = await marketContractProxy.getUserAddressOrDSProxy(takerAddress);
+        let makerDsProxyWallet = await marketContractProxy.getUserAddressOrDSProxy(
+          makerAddress
+        );
+        let takerDsProxyWallet = await marketContractProxy.getUserAddressOrDSProxy(
+          takerAddress
+        );
 
-        assert.equal(makerAddress, await marketContractProxy.dSProxyToAddress(makerDsProxyWallet), 'maker address mismatch');
-        assert.equal(takerAddress, await marketContractProxy.dSProxyToAddress(takerDsProxyWallet), 'taker address mismatch');
+        assert.equal(
+          makerAddress,
+          await marketContractProxy.dSProxyToAddress(makerDsProxyWallet),
+          "maker address mismatch"
+        );
+        assert.equal(
+          takerAddress,
+          await marketContractProxy.dSProxyToAddress(takerDsProxyWallet),
+          "taker address mismatch"
+        );
       });
 
-      it('batch redeem', async () => {
+      it("batch redeem", async () => {
         // for batch redeem txs
         let longTokensAddresses = [];
         let shortTokensAddresses = [];
@@ -832,19 +871,19 @@ contract(
         let amounts = [];
 
         let marketContract = await marketContractProxy.getAllMarketContracts();
-        
+
         let amount = new BigNumber(10);
 
         // deploy new markets to settle & batch redeem
         for (let i = marketContract.length; i < 33; i++) {
           let _marketAndsTokenNames = [];
-          _marketAndsTokenNames.push(web3.utils.fromAscii('BTC'));
-          _marketAndsTokenNames.push(web3.utils.fromAscii('MRI-BTC-28D-00000000-Long'));
-          _marketAndsTokenNames.push(web3.utils.fromAscii('MRI-BTC-28D-00000000-Short'));
+          _marketAndsTokenNames.push(web3.utils.fromAscii("BTC"));
+          _marketAndsTokenNames.push(web3.utils.fromAscii("MRI-BTC-28D-00000000-Long"));
+          _marketAndsTokenNames.push(web3.utils.fromAscii("MRI-BTC-28D-00000000-Short"));
           let _loopbackMri = new BigNumber(pc.getMRIDataForDay(i)).multipliedBy(
             new BigNumber(1e8)
           );
-          let _mri = new BigNumber(pc.getMRIDataForDay(i+1)).multipliedBy(
+          let _mri = new BigNumber(pc.getMRIDataForDay(i + 1)).multipliedBy(
             new BigNumber(1e8)
           );
           let _expiration = Math.round(new Date().getTime() / 1000) + 3600 * 24 * 35;
@@ -883,7 +922,7 @@ contract(
         let expectedTakerReturnedCollateral = new BigNumber(0);
         // settle last three contracts
         marketContract = await marketContractProxy.getAllMarketContracts();
-        for (let i = marketContract.length-3; i < marketContract.length; i++) {
+        for (let i = marketContract.length - 2; i < marketContract.length; i++) {
           let marketContractMpx = await MarketContractMPX.at(marketContract[i]);
 
           amounts.push(amount.toString());
@@ -893,36 +932,42 @@ contract(
           isLongToken.push(true);
           isShortToken.push(false);
 
-          await time.increaseTo(Math.round(new Date().getTime() / 1000) + 3600 * 24 * 40);
+          const currentTime = await marketContractProxy.getTime();
+          await time.increaseTo(Math.round(currentTime.toNumber() + 3600 * 24));
 
-          await marketContractProxy.settleMarketContract(_mri, marketContract[i], { from: honeyLemonOracle });
+          await marketContractProxy.settleMarketContract(_mri, marketContract[i], {
+            from: honeyLemonOracle
+          });
 
-          expectedMakerReturnedCollateral = expectedMakerReturnedCollateral.plus(calculateExpectedCollateralToReturn(
-            new BigNumber((await marketContractMpx.PRICE_FLOOR()).toString()),
-            new BigNumber((await marketContractMpx.PRICE_CAP()).toString()),
-            new BigNumber((await marketContractMpx.QTY_MULTIPLIER()).toString()),
-            new BigNumber(0),
-            amount,
-            new BigNumber((await marketContractMpx.settlementPrice()).toString())
-          ));
-          expectedTakerReturnedCollateral = expectedTakerReturnedCollateral.plus(calculateExpectedCollateralToReturn(
-            new BigNumber((await marketContractMpx.PRICE_FLOOR()).toString()),
-            new BigNumber((await marketContractMpx.PRICE_CAP()).toString()),
-            new BigNumber((await marketContractMpx.QTY_MULTIPLIER()).toString()),
-            amount,
-            new BigNumber(0),
-            new BigNumber((await marketContractMpx.settlementPrice()).toString())
-          ));
-          
-          assert.equal(
-            await marketContractMpx.isSettled(),
-            true
+          expectedMakerReturnedCollateral = expectedMakerReturnedCollateral.plus(
+            calculateExpectedCollateralToReturn(
+              new BigNumber((await marketContractMpx.PRICE_FLOOR()).toString()),
+              new BigNumber((await marketContractMpx.PRICE_CAP()).toString()),
+              new BigNumber((await marketContractMpx.QTY_MULTIPLIER()).toString()),
+              new BigNumber(0),
+              amount,
+              new BigNumber((await marketContractMpx.settlementPrice()).toString())
+            )
+          );
+          expectedTakerReturnedCollateral = expectedTakerReturnedCollateral.plus(
+            calculateExpectedCollateralToReturn(
+              new BigNumber((await marketContractMpx.PRICE_FLOOR()).toString()),
+              new BigNumber((await marketContractMpx.PRICE_CAP()).toString()),
+              new BigNumber((await marketContractMpx.QTY_MULTIPLIER()).toString()),
+              amount,
+              new BigNumber(0),
+              new BigNumber((await marketContractMpx.settlementPrice()).toString())
+            )
           );
 
+          assert.equal(await marketContractMpx.isSettled(), true);
+
           // time should be after last token's contract passed + settlement delay
-          if (marketContract.length-1 == i) {
+          if (marketContract.length - 1 == i) {
             // advance time after settlement delay
-            await time.increaseTo((await marketContractMpx.settlementTimeStamp()).toNumber() + (3600 * 24 * 1));
+            await time.increaseTo(
+              (await marketContractMpx.settlementTimeStamp()).toNumber() + 3600 * 24 * 1
+            );
           }
         }
 
@@ -934,21 +979,21 @@ contract(
         );
 
         // batch redeem call for long token
-        let longTokenBatchTx = marketContractProxy.contract.methods.batchRedeem(
-          longTokensAddresses,
-          amounts
-        )
-        .encodeABI();
+        let longTokenBatchTx = marketContractProxy.contract.methods
+          .batchRedeem(longTokensAddresses, amounts)
+          .encodeABI();
         // batch redeem call for short token
-        let shortTokenBatchTx = marketContractProxy.contract.methods.batchRedeem(
-          shortTokensAddresses,
-          amounts
-        ).encodeABI();
+        let shortTokenBatchTx = marketContractProxy.contract.methods
+          .batchRedeem(shortTokensAddresses, amounts)
+          .encodeABI();
 
         // DSProxy Wallet instance
-        let makerDsProxyWallet = await DSProxy.at(await marketContractProxy.getUserAddressOrDSProxy(makerAddress));
-        let takerDsProxyWallet = await DSProxy.at(await marketContractProxy.getUserAddressOrDSProxy(takerAddress));
-        
+        let makerDsProxyWallet = await DSProxy.at(
+          await marketContractProxy.getUserAddressOrDSProxy(makerAddress)
+        );
+        let takerDsProxyWallet = await DSProxy.at(
+          await marketContractProxy.getUserAddressOrDSProxy(takerAddress)
+        );
         // taker(investor) redeem long tokens
         await takerDsProxyWallet.execute(marketContractProxy.address, longTokenBatchTx, {
           from: takerAddress
@@ -969,12 +1014,12 @@ contract(
         assert.equal(
           makerImbtcBalanceAfter.minus(makerImbtcBalanceBefore).toString(),
           expectedMakerReturnedCollateral.toString(),
-          'maker returned collateral mismatch'
+          "maker returned collateral mismatch"
         );
         assert.equal(
           takerImbtcBalanceAfter.minus(takerImbtcBalanceBefore).toString(),
           expectedTakerReturnedCollateral.toString(),
-          'taker returned collateral mismatch'
+          "taker returned collateral mismatch"
         );
       });
     });

--- a/test/honeylemon/MinterBridge.test.js
+++ b/test/honeylemon/MinterBridge.test.js
@@ -15,7 +15,7 @@ const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000';
 
 contract(
   'MinterBridge',
-  ([owner, makerAddress, takerAddress, , , , , , _0xBridgeProxy, random]) => {
+  ([owner, makerAddress, takerAddress, , , , , _0xBridgeProxy, factoryOwner, random]) => {
     let minterBridge, marketContractProxy, collateralToken, sToken, lToken;
 
     before(async () => {


### PR DESCRIPTION
This PR add the needed modifications to activate the settlement delay feature.
- Set 24 hours as settlement delay.
- Transfer MarketContractMpx ownership to multisig after each contract deployment.
- Transfer MarketContractProxy ownership to multisig address.
- Update unit tests.