### PR TITLE
Update ownership transfer in migrations

### DIFF
--- a/migrations/2_market_protocol.js
+++ b/migrations/2_market_protocol.js
@@ -8,47 +8,25 @@ const MarketContractRegistry = artifacts.require('./MarketContractRegistry.sol')
 module.exports = async function(deployer, network, accounts) {
   if (network == 'skip-migrations') return;
 
-  // TODO: refactor this to not use .then notation in favour of using awaits
   // Note ownership transfer of MarketContractFactory, MarketCollateralPool and MarketContractRegistry occur
   // in a later migration after the MarketContractProxy has been deployed.
-  deployer.deploy(StringLib).then(function() {
-    return deployer.deploy(MathLib).then(function() {
-      return deployer.deploy(MarketContractRegistry).then(function() {
-        return deployer
-          .link(MathLib, [MarketContractMPX, MarketCollateralPool, MarketContractFactory])
-          .then(function() {
-            return deployer.link(StringLib, MarketContractMPX).then(function() {
-              return deployer
-                .deploy(
-                  MarketCollateralPool,
-                  MarketContractRegistry.address,
-                  '0x0000000000000000000000000000000000000000' // Market token Address should be unset.
-                )
-                .then(function() {
-                  return MarketCollateralPool.deployed().then(function() {
-                    return deployer
-                      .deploy(
-                        MarketContractFactory,
-                        MarketContractRegistry.address,
-                        MarketCollateralPool.address,
-                        accounts[0]
-                      )
-                      .then(function(factory) {
-                        return MarketContractRegistry.deployed().then(function(
-                          registryInstance
-                        ) {
-                          return registryInstance
-                            .addFactoryAddress(factory.address)
-                            .then(function() {
-                              console.log('💹 Done Market Migration!');
-                            });
-                        });
-                      });
-                  });
-                });
-            });
-          });
-      });
-    });
-  });
+  await deployer.deploy(StringLib);
+  await deployer.deploy(MathLib);
+  await deployer.deploy(MarketContractRegistry);
+  await deployer.link(MathLib, [MarketContractMPX, MarketCollateralPool, MarketContractFactory]);
+  await deployer.link(StringLib, MarketContractMPX);
+  await deployer.deploy(
+    MarketCollateralPool,
+    MarketContractRegistry.address,
+    '0x0000000000000000000000000000000000000000' // Market token Address should be unset.
+  );
+  const factory = await deployer.deploy(
+    MarketContractFactory,
+    MarketContractRegistry.address,
+    MarketCollateralPool.address,
+    accounts[0]
+  );
+  const registryInstance = await MarketContractRegistry.deployed();
+  await registryInstance.addFactoryAddress(factory.address);
+  console.log('💹 Done Market Migration!');
 };

--- a/migrations/2_market_protocol.js
+++ b/migrations/2_market_protocol.js
@@ -1,6 +1,5 @@
 const MathLib = artifacts.require('MathLib');
 const StringLib = artifacts.require('./libraries/StringLib.sol');
-const MarketToken = artifacts.require('./tokens/MarketToken.sol');
 const MarketContractMPX = artifacts.require('./mpx/MarketContractMPX.sol');
 const MarketContractFactory = artifacts.require('./mpx/MarketContractFactoryMPX.sol');
 const MarketCollateralPool = artifacts.require('./MarketCollateralPool.sol');
@@ -9,57 +8,47 @@ const MarketContractRegistry = artifacts.require('./MarketContractRegistry.sol')
 module.exports = async function(deployer, network, accounts) {
   if (network == 'skip-migrations') return;
 
-  if (network !== 'live') {
-    const gasLimit = (await web3.eth.getBlock('latest')).gasLimit;
-
-    return deployer.deploy(MarketToken).then(function() {
-      return deployer.deploy(StringLib).then(function() {
-        return deployer.deploy(MathLib).then(function() {
-          return deployer.deploy(MarketContractRegistry).then(function() {
-            return deployer
-              .link(MathLib, [
-                MarketContractMPX,
-                MarketCollateralPool,
-                MarketContractFactory
-              ])
-              .then(function() {
-                return deployer.link(StringLib, MarketContractMPX).then(function() {
-                  return deployer
-                    .deploy(
-                      MarketCollateralPool,
-                      MarketContractRegistry.address,
-                      MarketToken.address
-                    )
-                    .then(function() {
-                      return MarketCollateralPool.deployed().then(function() {
-                        return deployer
-                          .deploy(
-                            MarketContractFactory,
-                            MarketContractRegistry.address,
-                            MarketCollateralPool.address,
-                            accounts[0],
-                            {
-                              gas: gasLimit
-                            }
-                          )
-                          .then(function(factory) {
-                            return MarketContractRegistry.deployed().then(function(
-                              registryInstance
-                            ) {
-                              return registryInstance
-                                .addFactoryAddress(factory.address)
-                                .then(function() {
-                                  console.log('💹 Done Market Migration!');
-                                });
+  // TODO: refactor this to not use .then notation in favour of using awaits
+  // Note ownership transfer of MarketContractFactory, MarketCollateralPool and MarketContractRegistry occur
+  // in a later migration after the MarketContractProxy has been deployed.
+  deployer.deploy(StringLib).then(function() {
+    return deployer.deploy(MathLib).then(function() {
+      return deployer.deploy(MarketContractRegistry).then(function() {
+        return deployer
+          .link(MathLib, [MarketContractMPX, MarketCollateralPool, MarketContractFactory])
+          .then(function() {
+            return deployer.link(StringLib, MarketContractMPX).then(function() {
+              return deployer
+                .deploy(
+                  MarketCollateralPool,
+                  MarketContractRegistry.address,
+                  '0x0000000000000000000000000000000000000000' // Market token Address should be unset.
+                )
+                .then(function() {
+                  return MarketCollateralPool.deployed().then(function() {
+                    return deployer
+                      .deploy(
+                        MarketContractFactory,
+                        MarketContractRegistry.address,
+                        MarketCollateralPool.address,
+                        accounts[0]
+                      )
+                      .then(function(factory) {
+                        return MarketContractRegistry.deployed().then(function(
+                          registryInstance
+                        ) {
+                          return registryInstance
+                            .addFactoryAddress(factory.address)
+                            .then(function() {
+                              console.log('💹 Done Market Migration!');
                             });
-                          });
+                        });
                       });
-                    });
+                  });
                 });
-              });
+            });
           });
-        });
       });
     });
-  }
+  });
 };

--- a/migrations/4_market_contract_proxy.js
+++ b/migrations/4_market_contract_proxy.js
@@ -26,7 +26,7 @@ module.exports = async function(deployer, network, accounts) {
   let marketContractProxy = await deployer.deploy(
     MarketContractProxy,
     marketContractFactoryMPX.address,
-    accounts[0],
+    process.env.HONEYLEMON_ORACLE || accounts[0],
     minterBridge.address,
     collateralToken.address
   );

--- a/migrations/4_market_contract_proxy.js
+++ b/migrations/4_market_contract_proxy.js
@@ -1,6 +1,6 @@
 const MinterBridge = artifacts.require('MinterBridge');
 const MarketContractProxy = artifacts.require('MarketContractProxy');
-
+const MarketCollateralPool = artifacts.require('MarketCollateralPool');
 const MarketContractRegistry = artifacts.require('MarketContractRegistry');
 const CollateralToken = artifacts.require('CollateralToken');
 const MarketContractFactoryMPX = artifacts.require('MarketContractFactoryMPX');
@@ -8,6 +8,7 @@ const MarketContractFactoryMPX = artifacts.require('MarketContractFactoryMPX');
 module.exports = async function(deployer, network, accounts) {
   if (network == 'skip-migrations') return;
 
+  //TODO: update migrations to pull the address of this token from the respective network.
   // Deploy imBTC token
   await deployer.deploy(CollateralToken, 'Mock imBTC', 'imBTC', 1000000000000000, 8);
 
@@ -32,20 +33,35 @@ module.exports = async function(deployer, network, accounts) {
 
   console.log('👉 Deployed Market Contract Proxy');
 
-  marketContractProxy.transferOwnership(process.env.HONEYLEMON_MULTISIG || accounts[8]);
+  await marketContractProxy.transferOwnership(
+    process.env.HONEYLEMON_MULTISIG || accounts[8]
+  );
 
   // Transfer all appropriate rights from the deployed market protocol to marketContractProxy:
-  // Point the 0x MinterBridge to the marketContractProxy
+  // 1.a Point the 0x MinterBridge to the marketContractProxy & transfer ownership
   await minterBridge.setMarketContractProxyAddress(marketContractProxy.address);
 
-  // Ability for proxy to mint tokens for each market
+  // 1.b Transfer registry ownership to multisig
+  await minterBridge.transferOwnership(process.env.HONEYLEMON_MULTISIG || accounts[8]);
+
+  // 2.a Ability for proxy to mint tokens for each market.
   await registry.addAddressToWhiteList(marketContractProxy.address);
 
-  // Ability for proxy to push prices
+  // 2.b Transfer registry ownership to multisig
+  await registry.transferOwnership(process.env.HONEYLEMON_MULTISIG || accounts[8]);
+
+  // 3.a Ability for proxy to push prices
   await marketContractFactoryMPX.setOracleHubAddress(marketContractProxy.address);
 
-  // Ability for proxy to deploy new market protocol contracts
+  // 3.b Ability for proxy to deploy new market protocol contracts.
+  // NOTE: the Multisig is NOT the owner of the factory.
   await marketContractFactoryMPX.transferOwnership(marketContractProxy.address);
+
+  // 4.a Lastly, transfer ownership MarketCollateralPool to the multisig
+  const marketCollateralPool = await MarketCollateralPool.deployed();
+  await marketCollateralPool.transferOwnership(
+    process.env.HONEYLEMON_MULTISIG || accounts[8]
+  );
 
   console.log('🙇‍♂️ Transferred permissions to proxy');
 };

--- a/migrations/5_tokens_and_balances.js
+++ b/migrations/5_tokens_and_balances.js
@@ -1,10 +1,9 @@
 const PaymentToken = artifacts.require('PaymentToken');
-const CollateralToken = artifacts.require('CollateralToken');
 
 module.exports = async function(deployer, network, accounts) {
   if (network == 'skip-migrations') return;
 
-  // Deploy USDC token
+  // Deploy USDC token (mock)
   await deployer.deploy(PaymentToken, 'USDC', 'USDC', '10000000000000', 6);
   const paymentToken = await PaymentToken.deployed();
 

--- a/test/honeylemon/MinterBridge.test.js
+++ b/test/honeylemon/MinterBridge.test.js
@@ -15,7 +15,18 @@ const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000';
 
 contract(
   'MinterBridge',
-  ([owner, makerAddress, takerAddress, , , , , _0xBridgeProxy, factoryOwner, random]) => {
+  ([
+    owner,
+    makerAddress,
+    takerAddress,
+    ,
+    ,
+    ,
+    ,
+    _0xBridgeProxy,
+    honeyMultisig,
+    random
+  ]) => {
     let minterBridge, marketContractProxy, collateralToken, sToken, lToken;
 
     before(async () => {
@@ -54,7 +65,7 @@ contract(
       });
 
       it('set 0x Bridge Proxy', async () => {
-        await minterBridge.set0xBridgeProxy(_0xBridgeProxy, { from: owner });
+        await minterBridge.set0xBridgeProxy(_0xBridgeProxy, { from: honeyMultisig });
         assert.equal(
           await minterBridge.ERC20_BRIDGE_PROXY_ADDRESS(),
           _0xBridgeProxy,
@@ -116,7 +127,9 @@ contract(
 
       it('should revert when market contract proxy address is zero', async () => {
         // set market proxy address to address zero
-        await minterBridge.setMarketContractProxyAddress(ADDRESS_ZERO);
+        await minterBridge.setMarketContractProxyAddress(ADDRESS_ZERO, {
+          from: honeyMultisig
+        });
 
         await expectRevert(
           minterBridge.bridgeTransferFrom(
@@ -133,7 +146,9 @@ contract(
 
       it('call bridgeTransferFrom', async () => {
         // reset market proxy address to address zero
-        await minterBridge.setMarketContractProxyAddress(marketContractProxy.address);
+        await minterBridge.setMarketContractProxyAddress(marketContractProxy.address, {
+          from: honeyMultisig
+        });
 
         // call minter bridge
         await minterBridge.bridgeTransferFrom(


### PR DESCRIPTION
This PR updates ownership transfers in the migration script to ensure that the multisig is the owner of:
1) `MarketContractProxy`
2) `MinterBridge`
3) `MarketContractRegistry`
4) `marketCollateralPool`

The `MarketContractProxy` is the owner of the `MarketContractFactory` to enable new deployment of contracts at daily settlement time.

This PR also enables a `HONEYLEMON_ORACLE` env variable to be added to specify the oracle address for the `MarketContractProxy`.

Lastly, the Market Token was removed from the migrations in `2_market_protocol`.